### PR TITLE
Feature/testnet support

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,12 @@ import { PAYER_SK, OWNER_SK, DEVELOP_DOMAIN } from './developmode'
 import winston from 'winston'
 import fs from 'fs'
 
+import { config as bskConfig } from 'blockstack'
+import {
+   BlockstackNetwork,
+   BitcoindAPI
+} from 'blockstack/lib/network'
+
 const configDevelopDefaults = {
   winstonConsoleTransport: {
       level: 'info',
@@ -59,6 +65,9 @@ const configDefaults = {
   nameMinLength: 1
 }
 
+const BSK_TESTNET_API_URL = 'http://testnet.blockstack.org:16268'
+const BSK_TESTNET_BROADCAST_URL = 'http://testnet.blockstack.org:16269'
+const BSK_TESTNET_UTXO_URL = 'http://testnet.blockstack.org:18332'
 
 export function getConfig() {
   let config = Object.assign({}, configDefaults)
@@ -84,5 +93,17 @@ export function getConfig() {
     new winston.transports.Console(config.winstonConsoleTransport)
   ] }
 
+  // activate testnet if requested
+  if (process.env.BSK_TESTNET) {
+    const network = new BlockstackNetwork(
+      BSK_TESTNET_API_URL, BSK_TESTNET_BROADCAST_URL,
+      new BitcoindAPI(BSK_TESTNET_UTXO_URL,
+        { username: 'blockstack', password: 'blockstacksystem' }))
+
+    bskConfig.network = network
+    bskConfig.network.layer1.scriptHash = 196
+    bskConfig.network.layer1.pubKeyHash = 111
+  }
+  
   return config
 }

--- a/src/http.js
+++ b/src/http.js
@@ -123,7 +123,8 @@ export function makeHTTPServer(config) {
         res.write(JSON.stringify(status))
         res.end()
       })
-      .catch(() => {
+      .catch((e) => {
+        logger.error(e)
         res.writeHead(501, HEADERS)
         res.write(JSON.stringify(
           { status: false,

--- a/src/lookups.js
+++ b/src/lookups.js
@@ -37,7 +37,7 @@ export function isRegistrationValid(
     return Promise.resolve(false)
   }
   // owner should be a bitcoin address
-  const btcRegex = /^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$/
+  const btcRegex = /^[132mn][a-km-zA-HJ-NP-Z1-9]{25,34}$/
   if (!btcRegex.test(owner)) {
     logger.debug(`owner: ${owner} failed validation`)
     return Promise.resolve(false)


### PR DESCRIPTION
Make it so that if you set `BSK_TESTNET=1` when launching the subdomain registrar, you'll be able to interact with testnet.blockstack.org.