### PR TITLE
ci: remove notify jobs from ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,28 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  notify-start:
-    runs-on: ubuntu-latest
-    # Only run on non-PR events or only PRs that aren't from forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    outputs:
-      slack_message_id: ${{ steps.slack.outputs.message_id }}
-    steps:
-      - name: Notify slack start
-        if: success()
-        id: slack
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: devops-notify
-          status: STARTING
-          color: warning
-
   test:
     runs-on: ubuntu-latest
-    needs:
-      - notify-start
     steps:
       - uses: actions/checkout@v2
 
@@ -88,13 +68,11 @@ jobs:
         id: semantic
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SEMANTIC_RELEASE_PACKAGE: ${{ github.event.repository.name }}
         with:
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git
-            semantic-release-slack-bot
 
       - name: Login to Dockerhub
         uses: docker/login-action@v1
@@ -110,32 +88,3 @@ jobs:
           push: ${{ github.ref != 'refs/heads/main' || steps.semantic.outputs.new_release_version != '' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-
-  notify-end:
-    runs-on: ubuntu-latest
-    needs:
-      - build-publish
-    # Only run on non-PR events or only PRs that aren't from forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    steps:
-      - name: Notify slack success
-        if: (!contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled'))
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1.1.2
-        with:
-          message_id: ${{ needs.notify-start.outputs.slack_message_id }}
-          channel: devops-notify
-          status: SUCCESS
-          color: good
-
-      - name: Notify slack fail
-        if: contains(needs.*.result, 'failure')
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1.1.2
-        with:
-          message_id: ${{ needs.notify-start.outputs.slack_message_id }}
-          channel: devops-notify
-          status: FAILED
-          color: danger

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v2
         with:
-          images: ${{ github.repository }}
+          images: blockstack/${{ github.event.repository.name }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/package.json
+++ b/package.json
@@ -99,15 +99,7 @@
       ],
       "@semantic-release/github",
       "@semantic-release/changelog",
-      "@semantic-release/git",
-      [
-        "semantic-release-slack-bot",
-        {
-          "notifyOnSuccess": true,
-          "notifyOnFail": true,
-          "markdownReleaseNotes": true
-        }
-      ]
+      "@semantic-release/git"
     ]
   }
 }


### PR DESCRIPTION
## Description
Removes the notify jobs from the CI workflow, and allows other jobs to run on fork PRs.