### PR TITLE
ci: add conditions to allow fork PRs to run without secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2
         id: semantic
+        # Only run on non-PR events or only PRs that aren't from forks
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           SEMANTIC_RELEASE_PACKAGE: ${{ github.event.repository.name }}
@@ -75,6 +77,8 @@ jobs:
             @semantic-release/git
 
       - name: Login to Dockerhub
+        # Only run on non-PR events or only PRs that aren't from forks
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -85,6 +89,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: ${{ github.ref != 'refs/heads/main' || steps.semantic.outputs.new_release_version != '' }}
+          # Only push if (there's a new release on master branch, or if building a non-master branch) and (Only run on non-PR events or only PRs that aren't from forks)
+          push: ${{ (github.ref != 'refs/heads/master' || steps.semantic.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
## Description
Adds conditions to allow fork PRs to run without needing access to repo secrets.
