### PR TITLE
Fix lasttx_id: [object Object] issue

### DIFF
--- a/src/operations.js
+++ b/src/operations.js
@@ -206,8 +206,11 @@ export async function submitUpdate(
         headers: { 'Content-Type': 'application/json' }
       }
     )
-    const txHash = await result.json()
-    return txHash
+    const parsedResponse = await result.json()
+    if(result.status===200){
+      return parsedResponse
+    }
+    throw new Error(JSON.stringify(parsedResponse))
   } catch (err) {
     throw new Error('Error post transaction: ' + err.message)
   }


### PR DESCRIPTION
## Description
The problem was when a transaction is rejected for some reason It was not handling that and instead of marking it as complete.  This results in saving the error object in the DB as in place of tx_id hence the [object Object]. 


For details refer to issue #66 

## Type of Change
<!-- Explain or annotate the nature of your changes, see examples below -->
- Bug fix

## Testing information

added unit test for the behavior 