### PR TITLE
fix: avoid `/extended/v1/tx/<txid>` request that must follow redirects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         id: semantic
         # Only run on non-PR events or only PRs that aren't from forks
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/src/operations.js
+++ b/src/operations.js
@@ -275,7 +275,7 @@ export async function checkTransactions(
         try {
           txInfo = JSON.parse(reqText);
         } catch (error) {
-          logger.error(`Error parsing JSON from ${url} ${error}, received: ${reqText}`);
+          logger.error(`Error parsing JSON from ${url.toString()} ${error}, received: ${reqText}`);
           throw error;
         }
 

--- a/src/operations.js
+++ b/src/operations.js
@@ -267,7 +267,7 @@ export async function checkTransactions(
       if (!tx.blockHeight || tx.blockHeight <= 0) {
         // const txInfo = await bskConfig.network.getTransactionInfo(tx.txHash)
         const url = new URL(
-          bskConfig.network.coreApiUrl + `/extended/v1/tx/${tx.txHash}`
+          bskConfig.network.coreApiUrl + `/extended/v1/tx/0x${tx.txHash}`
         );
         const httpRequest = await fetch(url);
         const txInfo = await httpRequest.json();

--- a/src/operations.js
+++ b/src/operations.js
@@ -270,7 +270,14 @@ export async function checkTransactions(
           bskConfig.network.coreApiUrl + `/extended/v1/tx/0x${tx.txHash}`
         );
         const httpRequest = await fetch(url);
-        const txInfo = await httpRequest.json();
+        const reqText = await httpRequest.text();
+        let txInfo;
+        try {
+          txInfo = JSON.parse(reqText);
+        } catch (error) {
+          logger.error(`Error parsing JSON from ${url} ${error}, received: ${reqText}`);
+          throw error;
+        }
 
         if (!txInfo.block_height) {
           logger.info("Could not get block_height, probably unconfirmed.", {

--- a/tests/src/unitTestOperations.js
+++ b/tests/src/unitTestOperations.js
@@ -122,7 +122,7 @@ export function unitTestOperations() {
 
     txs.forEach(x => nock('https://stacks-node-api.mainnet.stacks.co')
       .persist()
-      .get(`/extended/v1/tx/${x.txHash}`)
+      .get(`/extended/v1/tx/0x${x.txHash}`)
       .reply(200, { block_height: x.blockheight }))
 
     // nock('https://stacks-node-api.mainnet.stacks.co')

--- a/tests/src/unitTestServer.js
+++ b/tests/src/unitTestServer.js
@@ -414,7 +414,7 @@ export function testSubdomainServer() {
 
     nock('https://stacks-node-api.mainnet.stacks.co')
       .persist()
-      .get(`/extended/v1/tx/${expected_tx}`)
+      .get(`/extended/v1/tx/0x${expected_tx}`)
       .reply(200, { block_height: 300 })
 
     await s.checkZonefiles() //todo


### PR DESCRIPTION
Adjust a network request to `/extended/v1/tx/<txid>` to use a `0x` prefix. This lets the `fetch` avoid needing to follow a redirect. 