### PR TITLE
feat: split API URLs into two env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12.22.12-bullseye-slim
 
 
 # Update apt and install wget

--- a/src/config.js
+++ b/src/config.js
@@ -97,7 +97,10 @@ export function getConfig() {
   }
   if (process.env.BLOCKSTACK_API_URL) {
     bskConfig.network.blockstackAPIUrl = process.env.BLOCKSTACK_API_URL
-    bskConfig.network.coreApiUrl = process.env.BLOCKSTACK_API_URL
+  }
+
+  if (process.env.BLOCKSTACK_CORE_URL) {
+    bskConfig.network.coreApiUrl = process.env.BLOCKSTACK_CORE_URL
   }
 
   config.winstonConfig = {


### PR DESCRIPTION
Splits the API URLs into two env vars, one for the Stacks Blockchain API, and another for the Stacks Core RPC API. This will allow anyone running the registrar to have greater control over the domains they use for each downstream service.